### PR TITLE
Update journal references for ccECP and set nrule for Tb

### DIFF
--- a/recipes/Co/ccECP-soft/author.txt
+++ b/recipes/Co/ccECP-soft/author.txt
@@ -1,1 +1,1 @@
-ccECP-soft from Kincaid et al. [arXiv (2022)](https://arxiv.org/abs/2207.02265) specifically developed for plane wave calculations.
+ccECP-soft from Kincaid et al. specifically developed for plane wave calculations. [J. Chem. Phys. 157, 174307 (2022)](https://doi.org/10.1063/5.0109098)

--- a/recipes/Cr/ccECP-soft/author.txt
+++ b/recipes/Cr/ccECP-soft/author.txt
@@ -1,1 +1,1 @@
-ccECP-soft from Kincaid et al. [arXiv (2022)](https://arxiv.org/abs/2207.02265) specifically developed for plane wave calculations.
+ccECP-soft from Kincaid et al. specifically developed for plane wave calculations. [J. Chem. Phys. 157, 174307 (2022)](https://doi.org/10.1063/5.0109098)

--- a/recipes/Cu/ccECP-soft/author.txt
+++ b/recipes/Cu/ccECP-soft/author.txt
@@ -1,1 +1,1 @@
-ccECP-soft from Kincaid et al. [arXiv (2022)](https://arxiv.org/abs/2207.02265) specifically developed for plane wave calculations.
+ccECP-soft from Kincaid et al. specifically developed for plane wave calculations. [J. Chem. Phys. 157, 174307 (2022)](https://doi.org/10.1063/5.0109098)

--- a/recipes/Fe/ccECP-soft/author.txt
+++ b/recipes/Fe/ccECP-soft/author.txt
@@ -1,1 +1,1 @@
-ccECP-soft from Kincaid et al. [arXiv (2022)](https://arxiv.org/abs/2207.02265) specifically developed for plane wave calculations.
+ccECP-soft from Kincaid et al. specifically developed for plane wave calculations. [J. Chem. Phys. 157, 174307 (2022)](https://doi.org/10.1063/5.0109098)

--- a/recipes/Mn/ccECP-soft/author.txt
+++ b/recipes/Mn/ccECP-soft/author.txt
@@ -1,1 +1,1 @@
-ccECP-soft from Kincaid et al. [arXiv (2022)](https://arxiv.org/abs/2207.02265) specifically developed for plane wave calculations.
+ccECP-soft from Kincaid et al. specifically developed for plane wave calculations. [J. Chem. Phys. 157, 174307 (2022)](https://doi.org/10.1063/5.0109098)

--- a/recipes/Ni/ccECP-soft/author.txt
+++ b/recipes/Ni/ccECP-soft/author.txt
@@ -1,1 +1,1 @@
-ccECP-soft from Kincaid et al. [arXiv (2022)](https://arxiv.org/abs/2207.02265) specifically developed for plane wave calculations.
+ccECP-soft from Kincaid et al. specifically developed for plane wave calculations. [J. Chem. Phys. 157, 174307 (2022)](https://doi.org/10.1063/5.0109098)

--- a/recipes/Sn/ccECP/author.txt
+++ b/recipes/Sn/ccECP/author.txt
@@ -1,1 +1,1 @@
-ccECP from A. Annaberdiyev et al. (unpublished)
+ccECP from A. Annaberdiyev et al. [arXiv (2023)](https://doi.org/10.48550/arXiv.2302.01903)

--- a/recipes/Tb/ccECP/Tb.ccECP.AREP.xml
+++ b/recipes/Tb/ccECP/Tb.ccECP.AREP.xml
@@ -1,7 +1,7 @@
 <pseudo version="0.5">
   <header symbol="Tb" atomic-number="65" zval="19" relativistic="no" polarized="no" creator="opium" flavor="Gaussian" core-corrections="no" parametrization="PBEGGA"/>
   <grid type="linear" units="bohr" ri="0.000000" rf="10.000000" npts="10001"/>
-  <semilocal units="hartree" format="r*V" npots-down="5" npots-up="0" l-local="4">
+  <semilocal units="hartree" format="r*V" npots-down="5" npots-up="0" l-local="4" nrule="7">
     <vps principal-n="0" l="s" spin="-1" cutoff="1.770000" occupation="2">
       <radfunc>
         <grid type="linear" units="bohr" ri="0.000000" rf="10.000000" npts="10001"/>

--- a/recipes/Tb/ccECP/Tb.ccECP.SOREP.xml
+++ b/recipes/Tb/ccECP/Tb.ccECP.SOREP.xml
@@ -1,7 +1,7 @@
 <pseudo version="0.5">
   <header symbol="Tb" atomic-number="65" zval="19" relativistic="yes" polarized="no" creator="opium" flavor="Gaussian" core-corrections="no" parametrization="PBEGGA"/>
   <grid type="linear" units="bohr" ri="0.000000" rf="10.000000" npts="10001"/>
-  <semilocal units="hartree" format="r*V" npots-down="5" npots-up="0" npots-so="3" l-local="4">
+  <semilocal units="hartree" format="r*V" npots-down="5" npots-up="0" npots-so="3" l-local="4" nrule="7">
     <vps principal-n="0" l="s" spin="-1" cutoff="1.770000" occupation="2">
       <radfunc>
         <grid type="linear" units="bohr" ri="0.000000" rf="10.000000" npts="10001"/>

--- a/recipes/Tb/ccECP/author.txt
+++ b/recipes/Tb/ccECP/author.txt
@@ -1,1 +1,1 @@
-ccECP from A. Annaberdiyev et al. (unpublished)
+ccECP from A. Annaberdiyev et al. [arXiv (2023)](https://doi.org/10.48550/arXiv.2302.01903)

--- a/recipes/Zn/ccECP-soft/author.txt
+++ b/recipes/Zn/ccECP-soft/author.txt
@@ -1,1 +1,1 @@
-ccECP-soft from Kincaid et al. [arXiv (2022)](https://arxiv.org/abs/2207.02265) specifically developed for plane wave calculations.
+ccECP-soft from Kincaid et al. specifically developed for plane wave calculations. [J. Chem. Phys. 157, 174307 (2022)](https://doi.org/10.1063/5.0109098)


### PR DESCRIPTION
This PR updates the journal references for Cr-Zn ccECP-soft (JCP) and Tb, Sn ccECP (arXiv).

In addition, I explicitly set the `nrule` in Tb so that the VMC energy matches the HF energy. Having this baked-in in the ECP file is better than expecting users to provide this in the QMC input file.