### PR TITLE
Fix Zr and Ta missing displays.

### DIFF
--- a/includes/below.php
+++ b/includes/below.php
@@ -1,6 +1,7 @@
 <!-- Markdown/HTML/Text can go here to be shown below the recipes -->
 ## Available ECPs and pseudopotentials
 
+* ccECPs from Haihan Zhou et al. [arxiv (2023)](https://arxiv.org/abs/2309.12145)
 * ccECP-soft from Benjamin Kincaid et al. specifically developed for plane wave calculations. [J. Chem. Phys. 157, 174307 (2022)](https://doi.org/10.1063/5.0109098)
 * ccECPs from Guangming Wang et al. [Journal of Chemical Physics 157 054101 (2022)](https://doi.org/10.1063/5.0087300)
 * ccECPs from Guangming Wang et al. [Journal of Chemical Physics 151, 144110 (2019)](https://doi.org/10.1063/1.5121006)
@@ -27,6 +28,7 @@ If you have a dataset, please create a pull request on the [GitHub site](https:/
 
 ## News and Major Updates
 
+* 2024-01-19 Added selected lanthanides and heavy elements ccECPs from Haihan Zhou et al. [arxiv (2023)](https://arxiv.org/abs/2309.12145)
 * 2022-09-01 Added softer potentials designed for plane-wave calculations from [J. Chem. Phys. 157, 174307 (2022)](https://doi.org/10.1063/5.0109098)
 * 2022-05-13 Added Gaussian format conversions of ccECPs and their basis sets courtesy [addman2 on GitHub](https://github.com/addman2)
 * 2022-04-04 Added selected heavy elements spin-orbit ccECPs from G. Wang et al. (2022) 

--- a/index.php
+++ b/index.php
@@ -81,7 +81,7 @@
 				<div id="rubidium" class="element element-block-1 alkali-metal" onclick="getRecipe('rubidium')">Rb</div>
 				<div id="strontium" class="element element-block-1 alkaline-earth-metal" onclick="getRecipe('strontium')">Sr</div>
 				<div id="yttrium" class="element element-block-1 transition-metal" onclick="getRecipe('yttrium')">Y</div>
-				<div id="zironium" class="element element-block-1 transition-metal" onclick="getRecipe('zironium')">Zr</div>
+				<div id="zirconium" class="element element-block-1 transition-metal" onclick="getRecipe('zirconium')">Zr</div>
 				<div id="niobium" class="element element-block-1 transition-metal" onclick="getRecipe('niobium')">Nb</div>
 				<div id="molybdenum" class="element element-block-1 transition-metal" onclick="getRecipe('molybdenum')">Mo</div>
 				<div id="technetium" class="element element-block-1 transition-metal" onclick="getRecipe('technetium')">Tc</div>
@@ -102,7 +102,7 @@
 				<div id="barium" class="element element-block-1 alkaline-earth-metal" onclick="getRecipe('barium')">Ba</div>
 				<div id="lanthanum" class="element element-block-1 lanthanide" onclick="getRecipe('lanthanum')">La</div>
 				<div id="hafnium" class="element element-block-1 transition-metal" onclick="getRecipe('hafnium')">Hf</div>
-				<div id="tatalum" class="element element-block-1 transition-metal" onclick="getRecipe('tatalum')">Ta</div>
+				<div id="tantalum" class="element element-block-1 transition-metal" onclick="getRecipe('tantalum')">Ta</div>
 				<div id="tungsten" class="element element-block-1 transition-metal" onclick="getRecipe('tungsten')">W</div>
 				<div id="rhenium" class="element element-block-1 transition-metal" onclick="getRecipe('rhenium')">Re</div>
 				<div id="osmium" class="element element-block-1 transition-metal" onclick="getRecipe('osmium')">Os</div>

--- a/recipes/Tb/ccECP/author.txt
+++ b/recipes/Tb/ccECP/author.txt
@@ -1,2 +1,2 @@
-ccECP from A. Annaberdiyev et al. [npj Quantum Materials (2023)](https://www.nature.com/articles/s41535-023-00583-6)
-ccECP from Haihan Zhou et al. [arxiv (2023)](https://arxiv.org/abs/2309.12145)
+ccECP from A. Annaberdiyev et al. [npj Quantum Materials (2023)](https://www.nature.com/articles/s41535-023-00583-6).
+See also Haihan Zhou et al. [arxiv (2023)](https://arxiv.org/abs/2309.12145)


### PR DESCRIPTION
As noted in the previous PR, there was a problem with correctly showing the files in Sn and Tb. @bkincaid256 noticed that Zr and Ta elements didn't display at all. It turns out this is due to a simple typo in the element names that are throwing off the PHP build. Once these are corrected, Zr, Ta, and other element files display properly.

Also added the relevant info in the `below.php` and restructured the Tb reference.